### PR TITLE
Client setParams fix

### DIFF
--- a/src/requesters/Client.php
+++ b/src/requesters/Client.php
@@ -96,11 +96,9 @@ class Client
     public function setParams($params)
     {
         $query = '';
+
         if ($params) {
-            $query .= '?';
-            $query .= collect($params)->map(function ($val, $key) {
-                return "{$key}=" . rawurlencode($val);
-            })->implode("&");
+            $query = '?' . http_build_query($params);
         }
 
         $this->params = $query;


### PR DESCRIPTION
Hi! The library fails when query parameters are passed to the client. The used "collect" function is not built-in PHP function nor imported with a use statement from somewhere else. So my proposition is to use the built-in "http_build_query" instead.